### PR TITLE
商品購入確認ページの高さの修正

### DIFF
--- a/app/assets/stylesheets/_confirmation.scss
+++ b/app/assets/stylesheets/_confirmation.scss
@@ -11,8 +11,7 @@
   }
   // メインコンテンツの設定
   .items_container{
-    width: 1440px;
-    height: 208px;
+    width: 100vw;
     .condition_format{
       width:700px;
       height: 208px;


### PR DESCRIPTION
# what
_confirmation.scssのクラスitems_containerの高さの調整
pxでの指定から100vhに変更した。
# why
別のディスプレイでフロントの確認をしてみるとフロントが崩れてしまっていたため。