### PR TITLE
【マークアップ】ユーザーログアウトページの修正

### DIFF
--- a/app/assets/stylesheets/logout.scss
+++ b/app/assets/stylesheets/logout.scss
@@ -1,14 +1,12 @@
 // ヘッダーの下の部分(以下sub_header)全体の設定
 .sub_header{
-  width:1440px;
-  height:49px;
+  width:100vw;
   box-shadow: 0 3px 3px 0 rgba(0,0,0,0.16);
   background-color: white;
 // sub_headerの各リンク先に関する設定
   .link_others{
     display:flex;
     width:1020px;
-    height:48px;
     margin: 0 auto;
     padding: 16px;
     // topページへのリンクに関する設定
@@ -45,7 +43,7 @@
   width: 1020px;
   height: 1425px;
   display:flex;
-  margin: 40px 194px;
+  margin: 40px auto;
   padding: 0 16px;
   .logout_form{
     width: 700px;


### PR DESCRIPTION
# what
ログアウトページのパンくず部分の横幅を調整
サイドバーとログアウトボタンの配置の再調整
# why
別のディスプレイで確認をするとレイアウトが崩れるため。