### PR TITLE
[WIP]【マークアップ】商品購入画面の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,3 +22,4 @@
 @import "logout.scss";
 @import "introduction";
 @import "edit";
+@import "purchase/index";

--- a/app/assets/stylesheets/purchase/_index.scss
+++ b/app/assets/stylesheets/purchase/_index.scss
@@ -1,0 +1,91 @@
+.buy__content {
+  padding: 32px 16px;
+  border-bottom: 1px solid #f5f5f5;
+  &__inner {
+    max-width: 343px;
+    margin: 0 auto;
+    .buy__form {
+      p {
+        line-height: 1.5;
+      }
+      .buy__price__table {
+        margin: 0 0 50px 0;
+        &-row {
+          border: 0;
+          font-size: 30px;
+          display: flex;
+          justify-content: space-between;
+          &-cell {
+            &-label {
+              font-size: 18px;
+            }
+          }
+        }
+      }
+    }
+    .buy__subtitle {
+      display: flex;
+      justify-content: space-between;
+      &--right {
+        color: #0099e8;
+        text-decoration: none;
+        &:hover {
+          text-decoration: underline;
+          opacity: 0.7;
+        }
+      }
+    }
+  }
+}
+
+.buy-content:first-of-type {
+  margin: 0;
+}
+
+.buy__item {
+  text-align: center;
+  &__box {
+    display: flex;
+    &-image {
+      height: 80px;
+      width: 80px;
+      min-width: 80px;
+    }
+    &__detail {
+      margin-left: 16px;
+      &-name {
+        font-size: 14px;
+        margin: 0;
+        padding: 0 0 8px;
+        line-height: 1.5;
+        text-align: left;
+      }
+      &-price {
+        margin: 0;
+        text-align: left;
+        font-size: 15px;
+      }
+    }
+  }
+}
+
+.buy__user__info {
+  text-align: left;
+  padding: 32px 0;
+  margin: 0;
+  border-top: 1px solid #f5f5f5;
+  &__text {
+    text-align: left;
+    margin: 8px 0 0;
+  }
+  &__card {
+    margin: 8px 0 0;
+  }
+  &:last-child {
+    padding: 0;
+  }
+}
+
+.bold {
+  font-weight: bold;
+}

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -5,6 +5,8 @@ class PurchaseController < ApplicationController
   before_action :redirect_to_seller_user
   before_action :set_card
 
+  layout "registrations"
+
   def index
     @image = Image.find_by(item_id: params[:format])
     if @card.blank?
@@ -16,6 +18,22 @@ class PurchaseController < ApplicationController
       customer = Payjp::Customer.retrieve(@card.customer_id)
       #保管したカードIDでpayjpから情報取得、カード情報表示のためインスタンス変数に代入
       @default_card_information = customer.cards.retrieve(@card.card_id)
+
+      @card_brand = @default_card_information.brand
+      case @card_brand
+      when "Visa"
+        @card_src = "//www-mercari-jp.akamaized.net/assets/img/card/visa.svg?2561606804"
+      when "JCB"
+        @card_src = "//www-mercari-jp.akamaized.net/assets/img/card/jcb.svg?2561606804"
+      when "MasterCard"
+        @card_src = "//www-mercari-jp.akamaized.net/assets/img/card/master-card.svg?2561606804"
+      when "American Express"
+        @card_src = "//www-mercari-jp.akamaized.net/assets/img/card/american_express.svg?2561606804"
+      when "Diners Club"
+        @card_src = "//www-mercari-jp.akamaized.net/assets/img/card/dinersclub.svg?2561606804"
+      when "Discover"
+        @card_src = "//www-mercari-jp.akamaized.net/assets/img/card/discover.svg?2561606804"
+      end
     end
   end
 

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -3,6 +3,7 @@ class PurchaseController < ApplicationController
   before_action :authenticate_user!
   before_action :set_item
   before_action :redirect_to_seller_user
+  before_action :redirect_to_soldout, except: [:done]
   before_action :set_card
 
   layout "registrations"
@@ -56,6 +57,10 @@ class PurchaseController < ApplicationController
 
   def redirect_to_seller_user
     redirect_to root_path  if current_user.id == @item.seller_id
+  end
+  
+  def redirect_to_soldout
+    redirect_to confirmation_items_path  if @item.buyer_id?
   end
 
   def set_card

--- a/app/views/purchase/done.html.haml
+++ b/app/views/purchase/done.html.haml
@@ -20,20 +20,3 @@
       %section.buy__content.buy__item
         .buy__content__inner
           =link_to "トップページへ戻る", root_path, class:"btn-default btn-red"
-
-
-
-
-
-
-
--# %h2 購入が完了しました
--# %br/
--# = @item.name
--# %br/
--# ¥
--# = @item.price
--# (送料込み)
--# %br/
--# = link_to root_path do
--#   トップページへ戻る

--- a/app/views/purchase/done.html.haml
+++ b/app/views/purchase/done.html.haml
@@ -1,10 +1,39 @@
-%h2 購入が完了しました
-%br/
-= @item.name
-%br/
-¥
-= @item.price
-(送料込み)
-%br/
-= link_to root_path do
-  トップページへ戻る
+.single-container
+  .user_header
+    %h1
+      = link_to image_tag("fmarket_logo_red.svg", size: "185x49", alt: "mercari", class: 'header_icon'), root_path
+
+  %main.single-main
+    %section.l-single-container
+      %h2.l-single-head.registration
+        購入が完了しました
+      %section.buy__content.buy__item
+        .buy__content__inner
+          .buy__item__box
+            .buy__item__box__detail
+              .buy__item__box__detail-name
+                = @item.name
+              %span.buy__item__box__detail-price.bold
+                ¥
+                = @item.price.to_s(:delimited)
+                （税込）送料込み
+      %section.buy__content.buy__item
+        .buy__content__inner
+          =link_to "トップページへ戻る", root_path, class:"btn-default btn-red"
+
+
+
+
+
+
+
+-# %h2 購入が完了しました
+-# %br/
+-# = @item.name
+-# %br/
+-# ¥
+-# = @item.price
+-# (送料込み)
+-# %br/
+-# = link_to root_path do
+-#   トップページへ戻る

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -1,37 +1,72 @@
-%h2 購入を確定しますか？
+.single-container
+  .user_header
+    %h1
+      = link_to image_tag("fmarket_logo_red.svg", size: "185x49", alt: "mercari", class: 'header_icon'), root_path
 
-.buy-product-image
-= image_tag @image.src.url, size: "200x200"
-
-.buy-product-name
-= @item.name
-
-.buy-product-price
-¥
-= @item.price
-（送料込み）
-
-%br
-%h3 支払い方法
-- if @default_card_information.blank?
-  %br /
-- else
-  -#以下カード情報を表示
-  = "**** **** **** " + @default_card_information.last4
-  - exp_month = @default_card_information.exp_month.to_s
-  - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
-  = exp_month + " / " + exp_year
-%br
-.buy-content__user-info__inner
-  %h3 配送先
-  .user-info-text
-    〒
-    = current_user.address.zipcode.to_s
-    %br
-    = current_user.address.prefecture.name
-    = current_user.address.city
-    = current_user.address.block
-    = current_user.address.building
-    = current_user.last_name
-    = current_user.first_name
-= button_to "購入する",  pay_purchase_index_path(@item), {method: :post, params: @item} 
+  %main.single-main
+    %section.l-single-container
+      %h2.l-single-head.registration
+        購入内容の確認
+      %section.buy__content.buy__item
+        .buy__content__inner
+          .buy__item__box
+            .buy__item__box-image
+              = image_tag @image.src.url, size: "80x80"
+            .buy__item__box__detail
+              .buy__item__box__detail-name
+                = @item.name
+              %span.buy__item__box__detail-price.bold
+                ¥
+                = @item.price.to_s(:delimited)
+                （税込）送料込み
+      %section.buy__content.buy__item
+        .buy__content__inner
+          = form_with(url: pay_purchase_index_path(@item), method: :post, params: @item, local: true, class: "buy__form") do |f|
+            .buy__price__table
+              .buy__price__table-row.bold
+                .buy__price__table-row-cell-label
+                  支払い金額
+                .buy__price__table-row-cell
+                  %span
+                    ¥
+                    = @item.price.to_s(:delimited)
+            %section.buy__user__info
+              .buy__content__inner
+                .buy__subtitle
+                  .buy__subtitle--left.bold
+                    支払い方法
+                  = link_to "変更する", card_index_path, class: "buy__subtitle--right"
+                - if @default_card_information.blank?
+                  %br
+                - else
+                  .buy__user__info__text
+                    クレジットカード
+                    %br
+                    = "**** **** **** " + @default_card_information.last4
+                    - exp_month = @default_card_information.exp_month.to_s
+                    - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
+                    %br
+                    有効期限
+                    %br
+                    = exp_month + " / " + exp_year
+                  %figure.buy__user__info__card
+                    = image_tag "#{@card_src}", width: '26', height: '20', alt: @card_brand
+            %section.buy__user__info
+              .buy__content__inner
+                .buy__subtitle
+                  .buy__subtitle--left.bold
+                    配送先
+                  = link_to "変更する", root_path, class: "buy__subtitle--right"
+                .buy__user__info__text
+                  〒
+                  = current_user.address.zipcode.to_s
+                  %br
+                  = current_user.address.prefecture.name
+                  = current_user.address.city
+                  = current_user.address.block
+                  = current_user.address.building
+                  %br
+                  = current_user.last_name
+                  = current_user.first_name
+            %section.buy__user__info
+              =f.submit "購入する", class:"btn-default btn-red"


### PR DESCRIPTION
# What
商品詳細ページから遷移するビューの実装を行った
- 商品購入確認画面 `purchase/index.html.haml`
画像が表示されないのは、本番環境で表示させるためのs3用のurlを利用しているためです。
![image](https://user-images.githubusercontent.com/57927432/72117218-3a05fe80-3390-11ea-99ba-5fab3ca84a4d.png)
![image](https://user-images.githubusercontent.com/57927432/72117224-3ffbdf80-3390-11ea-9e36-d6495479ee75.png)

- 商品購入完了画面 `purchase/done.html.haml`
![image](https://user-images.githubusercontent.com/57927432/72117238-4ee29200-3390-11ea-9f5a-06f6a72b92bc.png)

# Why
商品購入時に必要なビューのため